### PR TITLE
working decrypt_packet implementation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,12 @@
 [package]
 name = "libacc"
+authors = ["Amy Parker <amy@amyip.net>", "Kevin Liu <kevin.liu@csu.fullerton.edu>", "Owen de Vita <owend1117@gmail.com>"]
 version = "0.1.0"
 edition = "2021"
+rust-version = "1.72.0"
+description = "Library for the ACC protocol"
+repository = "https://github.com/amyipdev/libacc"
+license = "GPL-2.0-or-later"
 
 [dependencies]
 aes-gcm-siv = "0.11.1"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # libacc
 
-Library for the ACC protocol (README TBD)
+This is an early development version of the official ACC protocol library.
+We can't promise that it works perfectly yet - but this is the base for the 
+ongoing work on the ACC client implementation.
 
 ## Contributing
 

--- a/src/aes.rs
+++ b/src/aes.rs
@@ -29,7 +29,7 @@ pub(crate) fn encapsulate(pkt: &[u8], key: &[u8]) -> Result<Vec<u8>, std::io::Er
 /// Attempts to decrypt AES with a given key.
 /// If this fails, returns Err.
 /// On success, returns Ok(Vec<u8>) containing the packet.
-fn reveal(pkt: &[u8], key: &[u8]) -> Result<Vec<u8>, std::io::Error> {
+pub(crate) fn reveal(pkt: &[u8], key: &[u8]) -> Result<Vec<u8>, std::io::Error> {
     if key.len() != 32 {
         return Err(Error::from(ErrorKind::InvalidInput));
     }
@@ -47,6 +47,7 @@ fn reveal(pkt: &[u8], key: &[u8]) -> Result<Vec<u8>, std::io::Error> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use aes_gcm_siv::aead::OsRng;
 
     #[test]
     fn enc_rev_pkts_aes256_single_rand() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,3 +13,40 @@ pub fn encrypt_packet(pkt: &[u8], key: &[u8], vsn: i32) -> Result<Vec<u8>, Box<d
     };
     Ok(aes::encapsulate(&padding::encapsulate(&bson::encapsulate(&pv)?), key)?)
 }
+
+// According to RFC8452, this should never yield a "false packet"
+// (unlike OpenSSL's CBC mode), as GCM-SIV is AEAD
+pub fn decrypt_packet(pkt: &[u8], key: &[u8]) -> Result<PacketVersion, Box<dyn std::error::Error>> {
+    let aesd = aes::reveal(pkt, key)?;
+    let padd = padding::reveal(&aesd)?;
+    Ok(bson::reveal(&padd)?)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use aes_gcm_siv::KeyInit;
+
+    #[test]
+    fn basic_full_stack_packet() {
+        let key = aes_gcm_siv::Aes256GcmSiv::generate_key(aes_gcm_siv::aead::OsRng);
+        let pkt = b"ACC: the Aggressive Circumvention of Censorship project".to_vec();
+        // We allow irrefutable let patterns for now because we only have V1
+        // This won't be necessary later on - NOTE: remove when V2 releases
+        #[allow(irrefutable_let_patterns)]
+        if let PacketVersion::V1(d) = decrypt_packet(&encrypt_packet(&pkt, &key, 1).unwrap(), &key).unwrap() {
+            assert_eq!(pkt, d.d.bytes);
+        } else {
+            assert!(false);
+        }
+    }
+    #[test]
+    fn basic_negative() {
+        let key = aes_gcm_siv::Aes256GcmSiv::generate_key(aes_gcm_siv::aead::OsRng);
+        let key_bad = aes_gcm_siv::Aes256GcmSiv::generate_key(aes_gcm_siv::aead::OsRng);
+        let pkt = b"ACC: the Aggressive Circumvention of Censorship project".to_vec();
+        if let Ok(_) = decrypt_packet(&encrypt_packet(&pkt, &key, 1).unwrap(), &key_bad) {
+            assert!(false);
+        }
+    }
+}

--- a/src/padding.rs
+++ b/src/padding.rs
@@ -56,7 +56,7 @@ pub(crate) fn encapsulate(pkt: &[u8]) -> Vec<u8> {
 /// # Errors
 /// Returns an error if the padding is not valid (does not have the correct braces) or
 /// if there is an error during the extraction of BSON data.
-fn reveal(pkt: &[u8]) -> Result<Vec<u8>, std::io::Error> {
+pub(crate) fn reveal(pkt: &[u8]) -> Result<Vec<u8>, std::io::Error> {
     // initialize bson_front_index & bson_back_index with a default of -1 to indicate they hasn't been changed
     let mut bson_front_index: i32 = -1;
     let mut bson_back_index = -1;


### PR DESCRIPTION
This patch adds a working decrypt_packet implementation. With this, v0.1 of libacc is done, and ready for release on Crates.io.